### PR TITLE
Check an environment variable for the config file.

### DIFF
--- a/dockdev/dockdev.py
+++ b/dockdev/dockdev.py
@@ -11,7 +11,8 @@ def get_git():
   return git.Git()
   
 def get_config():
-  config_file = os.path.join(os.getcwd(), "config.json")
+  config_file_in_cwd = os.path.join(os.getcwd(), "config.json")
+  config_file = os.environ.get("DOCKDEV_CONFIG", config_file_in_cwd)
   with open(config_file) as fp:
     return parse_config(fp.read())
 


### PR DESCRIPTION
This allows dockdev to be run outside of the directory containing the
config, resolving #5.