### PR TITLE
Set the docker API version

### DIFF
--- a/dockdev/dockdev.py
+++ b/dockdev/dockdev.py
@@ -3,6 +3,7 @@ import sys, subprocess, os, json, argparse, itertools, git, docker, docker.utils
 
 def get_docker():
   kw = docker.utils.kwargs_from_env()
+  kw["version"] = "1.20"
   if kw and 'tls' in kw:
     kw['tls'].assert_hostname = False
   return docker.Client(**kw)


### PR DESCRIPTION
Set the docker API version, set the docker API version to a baseline compatible with Docker 1.8+ to avoid problems with docker-py having recently upgraded to 1.21 (docker 1.9)